### PR TITLE
Create dummy.h

### DIFF
--- a/dummy.h
+++ b/dummy.h
@@ -1,0 +1,9 @@
+#ifndef __ESP8266_ARDUINO-CYRPTOLIBS_H__
+#define __ESP8266_ARDUINO-CYRPTOLIBS_H__
+
+// empty header file. In Arduino IDE, include this header to enable the
+// IDE to "find" the library.
+// Then include the headers for the individual like ESP8266-Arduino-cryptolibs/sha256/sha256.h
+// that you want to use.
+
+#endif


### PR DESCRIPTION
Arduino CLI seems to have changed the behaivior to find headers see https://github.com/arduino/arduino-cli/issues/1275#issue-873805595

Simple fix by adding a dummy.h file for the IDE/CLI